### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,7 @@ homebrew_uninstalled_packages: []
 
 homebrew_upgrade_all_packages: no
 
-homebrew_taps:
-  - homebrew/core
+homebrew_taps: []
 
 homebrew_cask_apps: []
 


### PR DESCRIPTION
tapping homebrew/cask is no longer necessary because Homebrew now includes Cask functionality by default